### PR TITLE
Fix attribute stats

### DIFF
--- a/statsforecast.php
+++ b/statsforecast.php
@@ -729,7 +729,7 @@ class statsforecast extends Module
 					' . Shop::addSqlRestriction(Shop::SHARE_ORDER, 'o');
         $ca['ventil'] = Db::getInstance()->getRow($sql);
 
-        $sql = 'SELECT /*pac.id_attribute,*/ agl.name as gname, al.name as aname, COUNT(*) as total
+        $sql = 'SELECT /*pac.id_attribute,*/ agl.name as gname, al.name as aname, SUM(od.product_quantity) as total
 				FROM ' . _DB_PREFIX_ . 'orders o
 				LEFT JOIN ' . _DB_PREFIX_ . 'order_detail od ON o.id_order = od.id_order
 				INNER JOIN ' . _DB_PREFIX_ . 'product_attribute_combination pac ON od.product_attribute_id = pac.id_product_attribute


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Correct the attribute stats at the bottom. Orders with quantity > 1 will be taken into account correctly. See also below.
| Type?         | bug fix 
| BC breaks?    |  no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/27852
| How to test?  | Choose a time range with order which have items with a quantity > 1 and of course variants. Those quantites are missing in the stats. This bugfix fixes this. See below.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
